### PR TITLE
Fix priors for Schwen, Bachmann

### DIFF
--- a/Benchmark-Models/Bachmann_MSB2011/parameters_Bachmann_MSB2011.tsv
+++ b/Benchmark-Models/Bachmann_MSB2011/parameters_Bachmann_MSB2011.tsv
@@ -1,4 +1,4 @@
-parameterId	parameterName	parameterScale	lowerBound	upperBound	nominalValue	estimate	objectivePrior	objectivePriorParameters
+parameterId	parameterName	parameterScale	lowerBound	upperBound	nominalValue	estimate	objectivePriorType	objectivePriorParameters
 CISEqc	CISEqc	log10	0.001	10000	432.854027325732	1
 CISEqcOE	CISEqcOE	log10	0.001	1000	0.53027229006794	1
 CISInh	CISInh	log10	0.001	1000000000000	785221045.232906	1

--- a/Benchmark-Models/Schwen_PONE2014/parameters_Schwen_PONE2014.tsv
+++ b/Benchmark-Models/Schwen_PONE2014/parameters_Schwen_PONE2014.tsv
@@ -1,4 +1,4 @@
-parameterId	parameterName	parameterScale	lowerBound	upperBound	nominalValue	estimate	objectivePrior	objectivePriorParameters
+parameterId	parameterName	parameterScale	lowerBound	upperBound	nominalValue	estimate	objectivePriorType	objectivePriorParameters
 IR_obs_std	IR_{obs,std}	log10	1E-05	0.056234132519035	0.04718566713256	1
 fragments	fragments	lin	0	1	0.999999072086866	1
 ini_R1	ini_{R1}	log10	1E-05	1000	58.8503656504712	1	parameterScaleNormal	1.809765366817905;3


### PR DESCRIPTION
Increase accuracy and fix column name for prior specification (not sure why this was not detected by linting).