### PR TITLE
Set parameters and compartments to constant

### DIFF
--- a/Benchmark-Models/Perelson_Science1996/model_Perelson_Science1996.xml
+++ b/Benchmark-Models/Perelson_Science1996/model_Perelson_Science1996.xml
@@ -34,7 +34,7 @@
       </rdf:RDF>
     </annotation>
     <listOfCompartments>
-      <compartment metaid="metaid_0" sboTerm="SBO:0000410" id="default" size="1" constant="false"/>
+      <compartment metaid="metaid_0" sboTerm="SBO:0000410" id="default" size="1" constant="true"/>
     </listOfCompartments>
     <listOfSpecies>
       <species metaid="metaid_1" id="Tstar" compartment="default" initialConcentration="15061.32075" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
@@ -43,11 +43,11 @@
       <species metaid="metaid_4" id="Vni" compartment="default" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
     </listOfSpecies>
     <listOfParameters>
-      <parameter metaid="metaid_5" id="NN" value="480" constant="false"/>
-      <parameter metaid="metaid_6" id="T0" value="11000" constant="false"/>
-      <parameter metaid="metaid_7" id="c" value="2.06" constant="false"/>
-      <parameter metaid="metaid_8" id="delta" value="0.53" constant="false"/>
-      <parameter metaid="metaid_9" id="K0" value="3.9e-07" constant="false"/>
+      <parameter metaid="metaid_5" id="NN" value="480" constant="true"/>
+      <parameter metaid="metaid_6" id="T0" value="11000" constant="true"/>
+      <parameter metaid="metaid_7" id="c" value="2.06" constant="true"/>
+      <parameter metaid="metaid_8" id="delta" value="0.53" constant="true"/>
+      <parameter metaid="metaid_9" id="K0" value="3.9e-07" constant="true"/>
     </listOfParameters>
     <listOfReactions>
       <reaction metaid="metaid_12" id="v1" reversible="true" fast="false">


### PR DESCRIPTION
In the Perelson SBML model file the parameters and compartment were not set to constant, but I believe these should be constant as the model does not have any SBML rules or events.
