### PR TITLE
Isensee_JCB2018: fix SBML parameter values

### DIFF
--- a/Benchmark-Models/Isensee_JCB2018/model_Isensee_JCB2018.xml
+++ b/Benchmark-Models/Isensee_JCB2018/model_Isensee_JCB2018.xml
@@ -158,10 +158,10 @@
       <parameter metaid="kp_AC"                   id="kp_AC"                   value="0"/>
       <parameter metaid="kdp_AC"                  id="kdp_AC"                  value="0"/>
       <!-- H3: incomplete import -->
-      <parameter metaid="xi_i_Rp8_Br_cAMPS_pAB"   id="xi_i_Rp8_Br_cAMPS_pAB"   value="0"/>
-      <parameter metaid="xi_i_Rp8_pCPT_cAMPS_pAB" id="xi_i_Rp8_pCPT_cAMPS_pAB" value="0"/>
-      <parameter metaid="xi_i_Rp_cAMPS_pAB"       id="xi_i_Rp_cAMPS_pAB"       value="0"/>
-      <parameter metaid="xi_i_Sp8_Br_cAMPS_AM"    id="xi_i_Sp8_Br_cAMPS_AM"    value="0"/>
+      <parameter metaid="xi_i_Rp8_Br_cAMPS_pAB"   id="xi_i_Rp8_Br_cAMPS_pAB"   value="1"/>
+      <parameter metaid="xi_i_Rp8_pCPT_cAMPS_pAB" id="xi_i_Rp8_pCPT_cAMPS_pAB" value="1"/>
+      <parameter metaid="xi_i_Rp_cAMPS_pAB"       id="xi_i_Rp_cAMPS_pAB"       value="1"/>
+      <parameter metaid="xi_i_Sp8_Br_cAMPS_AM"    id="xi_i_Sp8_Br_cAMPS_AM"    value="1"/>
       <!-- H4: PDE inhibition -->
       <parameter metaid="xi_pPDE"                 id="xi_pPDE"                 value="0"/>
       <parameter metaid="kf_PDE_Csub"             id="kf_PDE_Csub"             value="0"/>

--- a/Benchmark-Models/Isensee_JCB2018/model_Isensee_JCB2018.xml
+++ b/Benchmark-Models/Isensee_JCB2018/model_Isensee_JCB2018.xml
@@ -149,10 +149,10 @@
       <parameter metaid="fourABnOH_level" id="fourABnOH_level" value="0" units="substance"/>
       <parameter metaid="fourABnOH_time" id="fourABnOH_incubation_time" value="0" units="time"/>
       <!-- H1: different KD -->
-      <parameter metaid="xi_KD_Rp8_Br_cAMPS"      id="xi_KD_Rp8_Br_cAMPS"      value="0"/>
-      <parameter metaid="xi_KD_Rp8_pCPT_cAMPS"    id="xi_KD_Rp8_pCPT_cAMPS"    value="0"/>
-      <parameter metaid="xi_KD_Rp_cAMPS"          id="xi_KD_Rp_cAMPS"          value="0"/>
-      <parameter metaid="xi_KD_Sp8_Br_cAMPS"      id="xi_KD_Sp8_Br_cAMPS"      value="0"/>
+      <parameter metaid="xi_KD_Rp8_Br_cAMPS"      id="xi_KD_Rp8_Br_cAMPS"      value="1"/>
+      <parameter metaid="xi_KD_Rp8_pCPT_cAMPS"    id="xi_KD_Rp8_pCPT_cAMPS"    value="1"/>
+      <parameter metaid="xi_KD_Rp_cAMPS"          id="xi_KD_Rp_cAMPS"          value="1"/>
+      <parameter metaid="xi_KD_Sp8_Br_cAMPS"      id="xi_KD_Sp8_Br_cAMPS"      value="1"/>
       <!-- H2: AC inhibition -->
       <parameter metaid="xi_pAC"                  id="xi_pAC"                  value="0"/>
       <parameter metaid="kp_AC"                   id="kp_AC"                   value="0"/>


### PR DESCRIPTION
In #132, this problem was changed to remove model selection parameters (if they were not selected).

All model selection parameters in the SBML model were also set to 0. This changed the value of the `xi_i_*` model selection parameters, which led to a change in the  objective function.

This PR reverses that change. AMICI previously expected a likelihood of `-3.9494e+03`. With the following code and this PR, I get a posterior of `-3953.8289641759175` (without prior: `-3949.3759644713145`, prior-only: `-4.452999704602744`)

```python
import petab
import amici
import pypesto.petab
pp = petab.Problem.from_yaml("Isensee_JCB2018.yaml")
pi = pypesto.petab.PetabImporter(pp)
p=pi.create_problem()
p.objective._objectives[0].amici_solver.setAbsoluteTolerance(1e-8)
p.objective._objectives[0].amici_solver.setRelativeTolerance(1e-8)
p.objective._objectives[0].amici_model.setSteadyStateSensitivityMode(amici.SteadyStateSensitivityMode.integrationOnly)
print(p.objective(pp.x_nominal_free_scaled, sensi_orders=(0,1)))
```

However, it's unclear to me whether this PR is an improvement, because in d2d, `xi_i_*` parameters are set to `0`.
https://github.com/Data2Dynamics/d2d/blob/f3e55b8600529ee213eb53b3e2a1628d44210b24/arFramework3/Examples/Isensee_JCB2018/Setup.m#L84-L90