### PR TITLE
Add .git_archival.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/python/.git_archival.txt  export-subst

--- a/src/python/.git_archival.txt
+++ b/src/python/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/src/python/build.sh
+++ b/src/python/build.sh
@@ -25,7 +25,7 @@ mkdir $BUILD_DIR
 # Copy code
 cp -r \
   $CODE_DIR \
-  "pyproject.toml" "MANIFEST.in" \
+  "pyproject.toml" "MANIFEST.in" ".git_archival.txt" \
   "../../LICENSE" "../../README.md" \
   $BUILD_DIR
 # Remove link


### PR DESCRIPTION
This will ensure that setuptools-scm also works with `git archive` outputs, and not only with repo clones.
