### PR TITLE
pages: Add overview table

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,8 +29,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.13
+      - name: Install dependencies
+        run: |
+          cd src/python
+          pip install --upgrade pip
+          pip install -e .[site]
       - name: Build site
         run: src/python/build_site.py
+      - name: Create overview
+        run: bmp-create-overview --html-file=_site/index.html
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Contributions to the collection are very welcome. Please see [CONTRIBUTING.md](C
 
 ## Overview
 
+The following table summarizes the problems in the collection.
+The full set of PEtab files are available in the respective subfolders.
+A sortable version of the table is available
+[here](https://benchmarking-initiative.github.io/Benchmark-Models-PEtab/).
+
 <!-- START OVERVIEW TABLE -->
 | PEtab Problem ID                                                                             |   Conditions |   Estimated Parameters |   Events | Possible Discontinuities   |   Preequilibration |   Postequilibration |   Measurements |   Observables | Noise distribution(s)   | Objective prior distribution(s)   |   Species | References                                                                                                                                                                                 | SBML4Humans                                                                                                                                                                                                                              |
 |:---------------------------------------------------------------------------------------------|-------------:|-----------------------:|---------:|:---------------------------|-------------------:|--------------------:|---------------:|--------------:|:------------------------|:----------------------------------|----------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pre-commit", "pytest", "ruff"]
+site = ["bokeh>=3.7.3"]
 
 [project.scripts]
 bmp-petablint = "benchmark_models_petab.check_petablint:main"


### PR DESCRIPTION
Show a sortable overview table on GitHub pages. To be prettified at some point.

:eyes: https://benchmarking-initiative.github.io/Benchmark-Models-PEtab/