### PR TITLE
CI: Python 3.10->3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository
@@ -26,7 +26,7 @@ jobs:
         pip install -e .
         pip install pytest
         pytest test
-    
+
     - name: Run tests from sdist install
       run: |
         cd src/python
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.12']
 
     steps:
     - name: Check out repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
Python 3.10->3.12 to support the latest libpetab-python.