### PR TITLE
Fix visualization file for Bruno_JExpBot2016 - inconsistent yScale

### DIFF
--- a/Benchmark-Models/Bruno_JExpBot2016/visualizationSpecification_Bruno_JExpBot2016.tsv
+++ b/Benchmark-Models/Bruno_JExpBot2016/visualizationSpecification_Bruno_JExpBot2016.tsv
@@ -15,5 +15,5 @@ plot8	$\beta$-carotene	LinePlot	MeanAndSD	model1_data2_obcar	time	0	Time [min]	o
 plot8	$\beta$-carotene	LinePlot	MeanAndSD	model1_data3_obcar	time	0	Time [min]	obcar	0	concentration [nmol]	model1_data3	lin	lin
 plot9	3-OH-$\beta$-apo-10-carotenal	LinePlot	MeanAndSD	model1_data4_oohb10	time	0	Time [min]	oohb10	0	concentration [nmol]	model1_data4	lin	lin
 plot9	3-OH-$\beta$-apo-10-carotenal	LinePlot	MeanAndSD	model1_data5_oohb10	time	0	Time [min]	oohb10	0	concentration [nmol]	model1_data5	lin	lin
-plot9	3-OH-$\beta$-apo-10-carotenal	LinePlot	MeanAndSD	model1_data6_oohb10	time	0	Time [min]	oohb10	0	concentration [nmol]	model1_data6	lin	log10
+plot9	3-OH-$\beta$-apo-10-carotenal	LinePlot	MeanAndSD	model1_data6_oohb10	time	0	Time [min]	oohb10	0	concentration [nmol]	model1_data6	lin	lin
 plot10 	zeaxanthin	LinePlot	MeanAndSD	model1_data6_ozea	time	0	Time [min]	ozea	0	concentration [nmol]	model1_data6	lin	log10


### PR DESCRIPTION
For  plot `plot9`, two lines have `yScale=lin`, one has `yScale=log10`. I am not sure if this would be allowed or not, but I don't think we want to mix `lin` and `log10` scaled lines inside a single subplot here.