### PR TITLE
Fix Fiedler: add visualization file to yaml

### DIFF
--- a/Benchmark-Models/Fiedler_BMCSystBiol2016/Fiedler_BMCSystBiol2016.yaml
+++ b/Benchmark-Models/Fiedler_BMCSystBiol2016/Fiedler_BMCSystBiol2016.yaml
@@ -9,3 +9,5 @@ problems:
   - observables_Fiedler_BMCSystBiol2016.tsv
   sbml_files:
   - model_Fiedler_BMCSystBiol2016.xml
+  visualization_files:
+  - visualizationSpecification_Fiedler_BMCSystBiol2016.tsv


### PR DESCRIPTION
There is a visualization file, but it's not referenced in the yaml file. Add it there as done for all other problems.
